### PR TITLE
TsLuaConfig: Static schema data initialization.

### DIFF
--- a/iocore/net/LuaSNIConfig.cc
+++ b/iocore/net/LuaSNIConfig.cc
@@ -1,0 +1,24 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "LuaSNIConfig.h"
+
+TsConfigDescriptor LuaSNIConfig::Item::FQDN_DESCRIPTOR{TsConfigDescriptor::Type::STRING, "String", "fqdn", "Fully Qualified Domain Name" };

--- a/iocore/net/LuaSNIConfig.h
+++ b/iocore/net/LuaSNIConfig.h
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-/* 
+/*
  * File:   LuaSNIConfig.h
  * Author: persia
  *
@@ -15,41 +15,38 @@
 #define LUASNICONFIG_H
 
 #include "tsconfig/TsConfigLua.h"
-#include "tsconfig/Errata.h"
-using namespace ts;
-class Errata;
+
+#include <vector>
+
+using ts::Errata;
+
 struct LuaSNIConfig : public TsConfigBase {
-   using self = LuaSNIConfig;
-   enum class Action { CLOSE, TUNNEL };
+  using self = LuaSNIConfig;
+  enum class Action { CLOSE, TUNNEL };
 
-   static TsConfigArrayDescriptor DESCRIPTOR;
-   LuaSNIConfig() : TsConfigBase(DESCRIPTOR) {}
+  static TsConfigArrayDescriptor DESCRIPTOR;
 
-   struct Item : public TsConfigBase {
-      Item() : TsConfigBase(DESCRIPTOR)
-         {
-          Item::FQDN_CONFIG = TsConfigString<Item>(FQDN_DESCRIPTOR, fqdn);
-         // Item::LEVEL_CONFIG = TsConfigInt<Item>(LEVEL_DESCRIPTOR, self::Item::level);
-          Item::ACTION_CONFIG = TsConfigEnum<Item,self::Action>(ACTION_DESCRIPTOR,action);
-      }
-      ts::Errata loader(lua_State* s) override;
+  LuaSNIConfig() : TsConfigBase(DESCRIPTOR) {}
 
-      std::string fqdn;
-      int level;
-      Action action;
+  struct Item : public TsConfigBase {
+    Item() : TsConfigBase(DESCRIPTOR), FQDN_CONFIG(FQDN_DESCRIPTOR, fqdn), ACTION_CONFIG(ACTION_DESCRIPTOR, action)  {}
+    ts::Errata loader(lua_State* s) override;
 
-      // These need to be initialized statically.
-      static TsConfigObjectDescriptor OBJ_DESCRIPTOR;
-      static TsConfigDescriptor FQDN_DESCRIPTOR;
-      static TsConfigString<Item> FQDN_CONFIG;
-      //static TsConfigDescriptor LEVEL_DESCRIPTOR;
-      //static TsConfigInt<Item> LEVEL_CONFIG;
-      static TsConfigEnumDescriptor ACTION_DESCRIPTOR;
-      static TsConfigEnum<Item, Action> ACTION_CONFIG;
-   };
-   static std::vector<Item> items;
-   ts::Errata loader(lua_State* s) override;
+    std::string fqdn;
+    int level;
+    Action action;
+
+    // These need to be initialized statically.
+    static TsConfigObjectDescriptor OBJ_DESCRIPTOR;
+    static TsConfigDescriptor FQDN_DESCRIPTOR;
+    TsConfigString FQDN_CONFIG;
+    //static TsConfigDescriptor LEVEL_DESCRIPTOR;
+    //static TsConfigInt<Item> LEVEL_CONFIG;
+    static TsConfigEnumDescriptor ACTION_DESCRIPTOR;
+    TsConfigEnum<Action> ACTION_CONFIG;
+  };
+  std::vector<Item> items;
+  ts::Errata loader(lua_State* s) override;
 };
 
 #endif /* LUASNICONFIG_H */
-

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -89,7 +89,7 @@ libinknet_a_SOURCES = \
   Inline.cc \
   I_SessionAccept.h \
   SessionAccept.cc \
-  LuaSNIConfig.h \
+  LuaSNIConfig.h LuaSNIConfig.cc \
   Net.cc \
   NetVConnection.cc \
   P_SNIActionPerformer.h \

--- a/lib/tsconfig/TsConfigLua.h
+++ b/lib/tsconfig/TsConfigLua.h
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-/* 
+/*
  * File:   TSConfigLua.h
  * Author: persia
  *
@@ -20,30 +20,59 @@
 #include "lua.h"
 #include <unordered_map>
 
-class TsConfigDescriptor {
-   enum class Type { ARRAY, OBJECT, INT, FLOAT, STRING, ENUM };
-   std::string name;
-   std::string description;
-   Type type;
-   std::string type_name;
+/** Static schema data for a configuration value.
+
+    This is a base class for data about a configuration value. This is intended to be a singleton
+    static instance that contains schema data that is the same for all instances of the
+    configuration value.
+*/
+struct TsConfigDescriptor {
+  /// Type of the configuration value.
+  enum class Type {
+    ARRAY, ///< A homogenous array of nested values.
+    OBJECT, ///< A set of fields, each a name / value pair.
+    INT, ///< Integer value.
+    FLOAT, ///< Floating point value.
+    STRING, ///< String.
+    ENUM ///< Enumeration (specialized).
+  };
+  Type type; ///< Value type.
+  std::string type_name; ///< Literal type name used in the schema.
+  std::string name; ///< Name of the configuration value.
+  std::string description; ///< Description of the  value.
 };
 
+/** Configuration item instance data.
+
+    This is an abstract base class for data about an instance of the value in a configuration
+    struct. Actual instances will be a subclass for a supported configuration item type. This holds
+    data that is per instance and therefore must be dynamically constructed as part of the
+    configuration struct construction. The related description classes in contrast are data that is
+    schema based and therefore can be static and shared among instances of the configuration struct.
+*/
 class TsConfigBase {
 public:
-   TsConfigBase(TsConfigDescriptor const& d) : descriptor(d) {}
-   TsConfigDescriptor const& descriptor;
+  /// Source of the value in the config struct.
+  enum class Source {
+    NONE, ///< No source, the value is default constructed.
+    SCHEMA, ///< Value set in schema.
+    CONFIG ///< Value set in configuration file.
+  };
+  /// Constructor - need the static descriptor.
+  TsConfigBase(TsConfigDescriptor const& d) : descriptor(d) {}
+  TsConfigDescriptor const& descriptor; ///< Static schema data.
+  Source source = Source::NONE; ///< Where the instance data came from.
 
-   virtual ts::Errata loader(lua_State* s) = 0;
+  /// Load the instance data from the Lua stack.
+  virtual ts::Errata loader(lua_State* s) = 0;
 };
 
-template < typename T >
 class TsConfigInt : public TsConfigBase {
    TsConfigInt(TsConfigDescriptor const& d, int& i) : TsConfigBase(d), ref(i) {}
    int & ref;
    ts::Errata loader(lua_State* s) override;
 };
 
-template < typename T >
 class TsConfigString : public TsConfigBase {
 public:
    TsConfigString(TsConfigDescriptor const& d, std::string& str) : TsConfigBase(d), ref(str) {}
@@ -56,7 +85,7 @@ public:
    ts::Errata loader(lua_State* s) override;
 };
 
-template < typename T, typename E >
+template < typename E >
 class TsConfigEnum : public TsConfigBase {
 public:
    TsConfigEnum(TsConfigDescriptor const& d, E& i) : TsConfigBase(d), ref(i) {}
@@ -85,4 +114,3 @@ class TsConfigObjectDescriptor : public TsConfigDescriptor {
 };
 
 #endif /* TSCONFIGLUA_H */
-


### PR DESCRIPTION
This does a few things:

* Demonstrates how to construct the static schema descriptors.
* Removes unneeded templates from the config instance structs.
* Adds some comments.
* Adds the source data, which we'll need later.
* Fixes some of the indentation to TS standards (you should really run clang-format on this to make collaboration easier).